### PR TITLE
Bug 2093986: Comply to restricted pod security level

### DIFF
--- a/deploy/deployment-base.yaml
+++ b/deploy/deployment-base.yaml
@@ -14,10 +14,18 @@ spec:
         app: pod-identity-webhook
     spec:
       serviceAccountName: pod-identity-webhook
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: pod-identity-webhook
         image: IMAGE
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         command:
         - /webhook
         - --in-cluster


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. 

/cc @s-urbaniak 