### PR TITLE
snyk: exclude vendor/

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**


### PR DESCRIPTION
...as we expect vulns in vendored deps to be caught by the dep scan.