### PR TITLE
OCPBUGS-74165: Fix GOTOOLCHAIN env var

### DIFF
--- a/hack/setup-go.sh
+++ b/hack/setup-go.sh
@@ -24,7 +24,7 @@ GO_IMAGE=public.ecr.aws/eks-distro-build-tooling/golang:$EKSD_GO_IMAGE_TAG-gcc
 # gotoolchain
 # https://go.dev/doc/toolchain
 export GOSUMDB="sum.golang.org"
-export GOTOOLCHAIN=go${GO_VERSION}
+export GOTOOLCHAIN=go${GO_VERSION#v}
 
 # force go modules
 export GO111MODULE=on


### PR DESCRIPTION
# Fix GOTOOLCHAIN invalid value when GO_VERSION has "v" prefix

## Problem

OKD builds for `ose-aws-pod-identity-webhook` started failing on 2026-01-16 with:

```
go: invalid GOTOOLCHAIN "gov1.24.11"
Go compliance shim [2148] [okd-4.21][ose-aws-pod-identity-webhook]: Exited with: 1
make: *** [Makefile:42: amazon-eks-pod-identity-webhook] Error 1
```

## Root Cause

The golang builder base image sets `GO_VERSION=v1.24.11` as an environment variable (with "v" prefix):

```dockerfile
ENV GO_VERSION=v1.24.11
```

When `hack/setup-go.sh` runs:

```bash
GO_VERSION="${GO_VERSION:-"$(cat .go-version)"}"
export GOTOOLCHAIN=go${GO_VERSION}
```

Since `GO_VERSION` is **already set in the environment**, the default substitution never triggers, and `GO_VERSION` retains the value `v1.24.11`.

This creates an invalid `GOTOOLCHAIN=gov1.24.11` (with extra "v"), which Go rejects.

## Why This Only Affected OKD Builds Recently

The bug existed all along, but was masked by the Go compliance shim in OpenShift builds:

| Build Type | `__doozer_group` | Go Compliance | Result |
|------------|------------------|---------------|--------|
| **OpenShift** (RHEL) | `openshift-4.21` | `EXEMPT: 0` → Forces `GOTOOLCHAIN=local` | Build succeeds ✅ |
| **OKD** (CentOS Stream) | `okd-4.21` | `EXEMPT: 1` → Does NOT override GOTOOLCHAIN | Build fails ❌ |

The Go compliance shim enforces FIPS compliance for OpenShift builds by forcing `GOTOOLCHAIN=local`, which overrode the invalid value. OKD builds are exempt from this enforcement, exposing the bug.

On 2026-01-12, OKD builds were mislabeled as `__doozer_group=openshift-4.21`, causing the compliance shim to activate and mask the bug. On 2026-01-16, the labeling was corrected to `okd-4.21`, exposing the issue.

## Solution

Normalize `GO_VERSION` by stripping any leading "v" prefix before using it in `GOTOOLCHAIN`:

```bash
# GO_VERSION may come from environment (with "v" prefix) or .go-version file (without)
GO_VERSION="${GO_VERSION:-"$(cat .go-version)"}"

# Strip "v" prefix for GOTOOLCHAIN compatibility
GO_VERSION="${GO_VERSION#v}"
```

This ensures `GOTOOLCHAIN=go1.24.11` regardless of whether `GO_VERSION` is set to `v1.24.11` or `1.24.11`.

## Testing

### Before Fix
```bash
export GO_VERSION=v1.24.11
source hack/setup-go.sh
echo $GOTOOLCHAIN  # Shows: gov1.24.11 ❌
```

### After Fix
```bash
export GO_VERSION=v1.24.11
source hack/setup-go.sh
echo $GOTOOLCHAIN  # Shows: go1.24.11 ✅
```

### Test builds
- OKD: [ose-aws-pod-identity-webhook-container-v4.22.0-202601191712.p2.g291c4b0.assembly.stream.scos9](https://okd-build-history-okd-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-aws-pod-identity-webhook-container-v4.22.0-202601191712.p2.g291c4b0.assembly.stream.scos9&outcome=success&type=image)
- OCP: [ose-aws-pod-identity-webhook-container-v4.22.0-202601191718.p2.g291c4b0.assembly.test.el9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-aws-pod-identity-webhook-container-v4.22.0-202601191718.p2.g291c4b0.assembly.test.el9&record_id=94095c6d-b369-8fe3-b153-86da107c8542&group=openshift-4.22)

### Compatibility
The fix works correctly in all scenarios:
- `GO_VERSION=v1.24.11` → `GOTOOLCHAIN=go1.24.11` ✅
- `GO_VERSION=1.24.11` → `GOTOOLCHAIN=go1.24.11` ✅
- `GO_VERSION` unset, `.go-version` contains `1.24.10` → `GOTOOLCHAIN=go1.24.10` ✅

## References

- Failed OKD build: 2026-01-16
- Successful OpenShift build: 2026-01-19
- Go toolchain documentation: https://go.dev/doc/toolchain