### PR TITLE
NO-ISSUE: Update OWNERS: remove 2uasimojo, suhanime, lleshchi

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,5 @@
 approvers:
-  - 2uasimojo
-  - suhanime
   - dlom
   - jstuever
-  - lleshchi
   - sjenning
 component: "Cloud Credential Operator"


### PR DESCRIPTION
Suhani and I were never truly owners of this repo, just backups due to arbitrary org chart lines. In the advent of PIXAA, we're *really* not owners anymore.

...and Leah left RH some time ago.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal approval permissions.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->